### PR TITLE
Revert "fix image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM --platform=linux/amd64 debian:bullseye-slim
+FROM --platform=linux/amd64 debian:bookworm-slim
 
-RUN apt-get update && apt-get install unzip openssl ca-certificates libssl1.1 -y
+RUN apt-get update && apt-get install unzip openssl ca-certificates -y
 COPY ./jupiter-swap-api-x86_64-unknown-linux-gnu.zip ./jupiter-swap-api-x86_64-unknown-linux-gnu.zip
 RUN unzip jupiter-swap-api-x86_64-unknown-linux-gnu.zip
 RUN rm jupiter-swap-api-x86_64-unknown-linux-gnu.zip


### PR DESCRIPTION
somehow the builder for the binary is using back the upgraded libssl...

Reverts jup-ag/jupiter-swap-api#5